### PR TITLE
Fix deprecated warnings and incorrect tests

### DIFF
--- a/MyLinkedList.java
+++ b/MyLinkedList.java
@@ -120,7 +120,7 @@ public abstract class MyLinkedList<T> {
 	}
 
 	/**
-	 * Check that an MyLinkedList<Integer> contains the same elements as an int array.
+	 * Check that an MyLinkedList<Integer> pops elements in the right order
 	 *
 	 * If the list and the array are not the same, throw an AssertionError.
 	 *
@@ -129,15 +129,22 @@ public abstract class MyLinkedList<T> {
 	 */
 	public static void assertIsEqual(MyLinkedList<Integer> list, int[] answer) {
 		if (list.size() != answer.length) {
-			throw new AssertionError("Expected list of length " + answer.length + " but got " + list.size());
+			throw new AssertionError("Reported size of lists were not equal, expected list of length " + answer.length + " but got " + list.size());
 		}
-		for (int i = 0; i < answer.length; i++) {
-			if (!list.get(i).equals(new Integer(answer[i]))) {
-				throw new AssertionError("Expected " + answer[i] + " but got " + list.get(i));
+
+		// Pop everything from the list
+		for (int expected : answer) {
+			int actual = list.pop();
+			if (actual != expected) {
+				throw new AssertionError("Expected " + expected + " but got " + actual);
 			}
 		}
-	}
 
+		// Add all those elements back
+		for (int ans : answer) {
+			list.add(ans);
+		}
+	}
 
 	public static void main(String[] args) {
 

--- a/MyQueue.java
+++ b/MyQueue.java
@@ -20,7 +20,7 @@ public class MyQueue<T> extends MyLinkedList<T> {
 	@Override
 	public T pop() {
 		// FIXME
-		return 0;
+		return null;
 	}
 
 	/**
@@ -31,7 +31,7 @@ public class MyQueue<T> extends MyLinkedList<T> {
 	@Override
 	public T peek() {
 		// FIXME
-		return 0;
+		return null;
 	}
 	
 	/**
@@ -49,14 +49,14 @@ public class MyQueue<T> extends MyLinkedList<T> {
 
 		// push some elements onto the Stack
 		for (int i = 0; i < 5; i++) {
-			list.push(new Integer (i * i));
+			list.push(Integer.valueOf(i * i));
 		}
 		int[] answer2 ={0,1,4,9,16};
 		assertIsEqual(list, answer2);
 
 		// delete some numbers in the middle
-		list.remove(new Integer(1));
-		list.remove(new Integer(2));
+		list.remove(Integer.valueOf(1));
+		list.remove(Integer.valueOf(2));
 		int[] answer3 = {0,4,16};
 		assertIsEqual(list, answer3);
 
@@ -67,7 +67,7 @@ public class MyQueue<T> extends MyLinkedList<T> {
 		assertIsEqual(list, answer4);
 
 		// delete the final remaining number
-		list.remove(new Integer(0));
+		list.remove(Integer.valueOf(0));
 		int[] answer5 = {};
 		assertIsEqual(list, answer5);
 

--- a/MyStack.java
+++ b/MyStack.java
@@ -50,15 +50,15 @@ public class MyStack<T> extends MyLinkedList<T> {
 
 		// push some elements onto the Stack
 		for (int i = 0; i < 5; i++) {
-			list.push(new Integer (i * i));
+			list.push(Integer.valueOf(i * i));
 		}
-		int[] answer2 = {0,1,4,9,16};
+		int[] answer2 = {16,9,4,1};
 		assertIsEqual(list, answer2);
 
 		// delete some numbers in the middle
-		list.remove(new Integer(1));
-		list.remove(new Integer(2));
-		int[] answer3 = {0,4,16};
+		list.remove(Integer.valueOf(1));
+		list.remove(Integer.valueOf(2));
+		int[] answer3 = {16,4,0};
 		assertIsEqual(list, answer3);
 
 		// pop some numbers from the stack
@@ -68,7 +68,7 @@ public class MyStack<T> extends MyLinkedList<T> {
 		assertIsEqual(list, answer4);
 
 		// delete the final remaining number
-		list.remove(new Integer(0));
+		list.remove(Integer.valueOf(0));
 		int[] answer5 = {};
 		assertIsEqual(list, answer5);
 


### PR DESCRIPTION
This PR fixes several issues that I noticed when I was completing the project:

1. The `Integer -> int` conversion methods use the deprecated constructor `new Integer(n)`
2. Some of the method signatures are incorrect, because when the project was taught originally, it used only `int`s, and now generics are used, which require `null` to be used as the stubs in some functions, instead of a number
3. The testing method `assertIsEqual` incorrectly used the order of the backing `LinkedList` to check for equality with the implementation of a queue, however, the user can either treat the head or tail of the list as the `head` of the queue in their own implementation, which is completely correct in terms of the `push()` and `pop()` methods, but would output an error incorrectly, since the ordering of nodes in the `LinkedList` would be incorrect

Please let me know if there is any work that I could put into this, in particular, I think that there maybe should be two methods in the `LinkedList` class that test for the correctness of the queue and stack respectively